### PR TITLE
Renamed pins on RGB LED to be more desciptive.

### DIFF
--- a/Diode_5mm_RGB_LED_Common_Cathode.kicad_mod
+++ b/Diode_5mm_RGB_LED_Common_Cathode.kicad_mod
@@ -1,4 +1,4 @@
-(module Diode_5mm_RGB_LED_Common_Cathode (layer F.Cu) (tedit 54692100)
+(module Diode_5mm_RGB_LED_Common_Cathode (layer F.Cu) (tedit 547BBE48)
   (descr "5mm common cathode RGB LED")
   (tags "RGB, LED, 5mm, Common Cathode")
   (fp_text reference Diode_5mm_RGB_LED_Common_Cathode (at 0 -1.905) (layer F.SilkS) hide
@@ -10,8 +10,8 @@
   (fp_line (start -1.1 -0.595) (end -1.55 -0.595) (layer F.SilkS) (width 0.15))
   (fp_circle (center 0 1.905) (end 2.95 1.905) (layer F.SilkS) (width 0.15))
   (fp_line (start 1.1 -0.595) (end 1.55 -0.595) (layer F.SilkS) (width 0.15))
-  (pad 1 thru_hole oval (at 0 0) (size 1.905 1.1176) (drill 0.762) (layers *.Cu *.Mask F.SilkS))
-  (pad 2 thru_hole rect (at 0 1.27) (size 1.905 1.1176) (drill 0.762) (layers *.Cu *.Mask F.SilkS))
-  (pad 3 thru_hole oval (at 0 2.54) (size 1.905 1.1176) (drill 0.762) (layers *.Cu *.Mask F.SilkS))
-  (pad 4 thru_hole oval (at 0 3.81) (size 1.905 1.1176) (drill 0.762) (layers *.Cu *.Mask F.SilkS))
+  (pad RA thru_hole oval (at 0 0) (size 1.905 1.1176) (drill 0.762) (layers *.Cu *.Mask F.SilkS))
+  (pad CC thru_hole rect (at 0 1.27) (size 1.905 1.1176) (drill 0.762) (layers *.Cu *.Mask F.SilkS))
+  (pad BA thru_hole oval (at 0 2.54) (size 1.905 1.1176) (drill 0.762) (layers *.Cu *.Mask F.SilkS))
+  (pad GA thru_hole oval (at 0 3.81) (size 1.905 1.1176) (drill 0.762) (layers *.Cu *.Mask F.SilkS))
 )


### PR DESCRIPTION
The pin names now match corresponding schematic component (device/LED_RGB_CC in kicad-library).
