### PR TITLE
added GBU  Diode_Bridge_18_5x5_5 3D model

### DIFF
--- a/Diode_Bridge_18.5x5.5.kicad_mod
+++ b/Diode_Bridge_18.5x5.5.kicad_mod
@@ -26,4 +26,9 @@
   (pad 2 thru_hole circle (at 5.1 0) (size 2.1 2.1) (drill 1.3) (layers *.Cu *.Mask))
   (pad 1 thru_hole circle (at 15.3 0) (size 2.1 2.1) (drill 1.3) (layers *.Cu *.Mask))
   (pad 4 thru_hole circle (at 10.2 0) (size 2.1 2.1) (drill 1.3) (layers *.Cu *.Mask))
+  (model Diodes_THT.3dshapes/Diode_Bridge_18_5x5_5.wrl
+    (at (xyz 0 0 0))
+    (scale (xyz 1 1 1))
+    (rotate (xyz 0 0 0))
+  )
 )


### PR DESCRIPTION
Updated footprint to point to new model
I noticed that all footprints point to Diodes_THT but the kicad-library repo still has Diodes_ThroughHole, so I used the new Diodes_THT directory assuming they will migrate